### PR TITLE
Fix Steam and Lutris issue

### DIFF
--- a/src/linux/launchers/heroic/heroic_amazon.rs
+++ b/src/linux/launchers/heroic/heroic_amazon.rs
@@ -48,15 +48,13 @@ impl HeroicAmazon {
             self.path_nile_library
         );
 
-        parse_all_games_from_library(&self.path_nile_library).map(|data| {
+        parse_all_games_from_library(&self.path_nile_library).inspect(|data| {
             if data.is_empty() {
                 warn!(
                     "No games were parsed from the Nile library file at {:?}",
                     self.path_nile_library
                 )
             };
-
-            data
         })
     }
 }

--- a/src/linux/launchers/heroic/heroic_epic.rs
+++ b/src/linux/launchers/heroic/heroic_epic.rs
@@ -48,15 +48,13 @@ impl HeroicEpic {
             self.path_legendary_library
         );
 
-        parse_all_games_from_library(&self.path_legendary_library).map(|data| {
+        parse_all_games_from_library(&self.path_legendary_library).inspect(|data| {
             if data.is_empty() {
                 warn!(
                     "No games were parsed from the Legendary library file at {:?}",
                     self.path_legendary_library
                 )
             };
-
-            data
         })
     }
 }

--- a/src/linux/launchers/minecraft/at.rs
+++ b/src/linux/launchers/minecraft/at.rs
@@ -138,14 +138,15 @@ mod tests {
         dbg!(&games);
         assert_eq!(games.len(), 2);
 
-        assert_eq!(games[0].title, get_minecraft_title("Sky Factory"));
-        assert_eq!(games[1].title, get_minecraft_title("Fabulously Optimized"));
+        assert!(games
+            .iter()
+            .any(|g| g.title == get_minecraft_title("Sky Factory")));
+        assert!(games
+            .iter()
+            .any(|g| g.title == get_minecraft_title("Fabulously Optimized")));
 
-        assert!(games[0].path_game_dir.is_some());
-        assert!(games[1].path_game_dir.is_some());
-
-        assert!(games[0].path_box_art.is_none());
-        assert!(games[1].path_box_art.is_none());
+        assert!(games.iter().all(|g| g.path_game_dir.is_some()));
+        assert!(games.iter().all(|g| g.path_box_art.is_none()));
 
         Ok(())
     }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -42,7 +42,7 @@ impl GamesDetectorLinux {
             Arc::new(HeroicGOG::new(path_home, path_config)),
             Arc::new(HeroicEpic::new(path_home, path_config)),
             Arc::new(HeroicAmazon::new(path_home, path_config)),
-            Arc::new(Lutris::new(path_home, path_config, path_cache)),
+            Arc::new(Lutris::new(path_home, path_config, path_cache, path_data)),
             Arc::new(Bottles::new(path_home, path_data)),
             Arc::new(MinecraftPrism::new(path_home, path_data)),
             Arc::new(MinecraftAT::new(path_home, path_data)),


### PR DESCRIPTION
Closes #14 

- Add fallbacks for Lutris games and coverart dirs as it appears that Lutris places things in different places than would be expected when no XDG env variables are set
- Avoid error when user has no shortcuts for non-Steam games