### PR TITLE
fix: avoid taking DLC titles as the title for Heroic Launcher Epic games

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib_game_detector"
-version = "0.0.17"
+version = "0.0.18"
 edition = "2021"
 description = "A Rust library for detecting and parsing data about games installed on the system"
 readme = "README.md"

--- a/src/linux/launchers/heroic/amazon.rs
+++ b/src/linux/launchers/heroic/amazon.rs
@@ -9,7 +9,8 @@ use super::ParsableLibraryData;
 use crate::{
     data::{Game, GamesResult, Launcher, SupportedLaunchers},
     linux::launchers::heroic::{
-        get_heroic_config_path, get_launch_command_for_heroic_source, parse_all_games_from_library,
+        get_heroic_config_path, get_launch_command_for_heroic_source,
+        parse_all_games_from_library_common,
     },
     macros::logs::{debug_path, warn_no_games},
     utils::{some_if_dir, some_if_file},
@@ -48,7 +49,7 @@ impl HeroicAmazon {
             self.path_nile_library
         );
 
-        parse_all_games_from_library(&self.path_nile_library).inspect(|data| {
+        parse_all_games_from_library_common(&self.path_nile_library).inspect(|data| {
             if data.is_empty() {
                 warn!(
                     "{LAUNCHER} - No games were parsed from the Nile library file at {:?}",

--- a/src/linux/launchers/heroic/epic.rs
+++ b/src/linux/launchers/heroic/epic.rs
@@ -9,7 +9,8 @@ use super::ParsableLibraryData;
 use crate::{
     data::{Game, GamesResult, Launcher, SupportedLaunchers},
     linux::launchers::heroic::{
-        get_heroic_config_path, get_launch_command_for_heroic_source, parse_all_games_from_library,
+        get_heroic_config_path, get_launch_command_for_heroic_source,
+        parse_all_games_from_library_common,
     },
     macros::logs::{debug_path, warn_no_games},
     utils::{some_if_dir, some_if_file},
@@ -48,7 +49,7 @@ impl HeroicEpic {
             self.path_legendary_library
         );
 
-        parse_all_games_from_library(&self.path_legendary_library).inspect(|data| {
+        parse_all_games_from_library_common(&self.path_legendary_library).inspect(|data| {
             if data.is_empty() {
                 warn!(
                     "{LAUNCHER} - No games were parsed from the Legendary library file at {:?}",

--- a/tests/file_system_mocks/linux/.config/heroic/store_cache/legendary_library.json
+++ b/tests/file_system_mocks/linux/.config/heroic/store_cache/legendary_library.json
@@ -77,6 +77,24 @@
 				"reqs": [],
 				"storeUrl": "https://www.epicgames.com/store/product/rocket-league"
 			},
+			"dlcList": [
+				{
+					"namespace": "9773aa1aa54f4f7b80e44bef04986cea",
+					"releaseInfo": [],
+					"requiresSecureAccount": false,
+					"status": "ACTIVE",
+					"title": "S7E2 Audience",
+					"unsearchable": true
+				},
+				{
+					"namespace": "9773aa1aa54f4f7b80e44bef04986cea",
+					"releaseInfo": [],
+					"requiresSecureAccount": false,
+					"status": "ACTIVE",
+					"title": "Rocket League® - Season 18 Rocketeer Pack",
+					"unsearchable": true
+				}
+			],
 			"folder_name": "rocketleague",
 			"install": {
 				"executable": "Binaries/Win64/RocketLeague.exe",
@@ -102,4 +120,3 @@
 		"library": "Sun Oct 29 2023 01:48:00 GMT+0100 (Irish Standard Time)"
 	}
 }
-

--- a/tests/file_system_mocks/linux/.var/app/com.heroicgameslauncher.hgl/config/heroic/store_cache/legendary_library.json
+++ b/tests/file_system_mocks/linux/.var/app/com.heroicgameslauncher.hgl/config/heroic/store_cache/legendary_library.json
@@ -77,6 +77,24 @@
 				"reqs": [],
 				"storeUrl": "https://www.epicgames.com/store/product/rocket-league"
 			},
+			"dlcList": [
+				{
+					"namespace": "9773aa1aa54f4f7b80e44bef04986cea",
+					"releaseInfo": [],
+					"requiresSecureAccount": false,
+					"status": "ACTIVE",
+					"title": "S7E2 Audience",
+					"unsearchable": true
+				},
+				{
+					"namespace": "9773aa1aa54f4f7b80e44bef04986cea",
+					"releaseInfo": [],
+					"requiresSecureAccount": false,
+					"status": "ACTIVE",
+					"title": "Rocket League® - Season 18 Rocketeer Pack",
+					"unsearchable": true
+				}
+			],
 			"folder_name": "rocketleague",
 			"install": {
 				"executable": "Binaries/Win64/RocketLeague.exe",
@@ -102,4 +120,3 @@
 		"library": "Sun Oct 29 2023 01:48:00 GMT+0100 (Irish Standard Time)"
 	}
 }
-


### PR DESCRIPTION
This required separating the parsing of side-load apps into a separate function, since the fields appear in a different order to the Nile and Legendary libraries.

Why must you be like this Heroic :(