### PR TITLE
fix: ignore case of 'steamapps' directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib_game_detector"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 description = "A Rust library for detecting and parsing data about games installed on the system"
 readme = "README.md"


### PR DESCRIPTION
In relation to #26.

The "steamapps" directory is capitalised on some users' systems, so simply check if the capitalised version exists first before defaulting to the lower-case name.