### PR TITLE
fix: parse Steam shortcuts from all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ let all_games_from_steam = detector.get_all_detected_games_from_specific_launche
 ## Currently supported game sources
 
 - Steam
-  - Non-Steam games added as shortcuts are also supported. Make sure to restart Steam at least once for new shortcuts to be detected
+  - Non-Steam games added as shortcuts are also supported. Just make sure to launch newly added
+    shortcuts through Steam at at least once for them to be detected correctly (some files need
+    to be generated).
 - Heroic Games Launcher (Legendary, Nile, GOG, and manually added games)
 - Lutris
 - Bottles

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,9 @@
 //! # Currently supported game sources
 //!
 //! - Steam
-//!   - Non-Steam games added as shortcuts are also supported. Make sure to restart Steam at least once for new shortcuts to be detected
+//!   - Non-Steam games added as shortcuts are also supported. Just make sure to launch newly added
+//!     shortcuts through Steam at at least once for them to be detected correctly (some files need
+//!     to be generated).
 //! - Heroic Games Launcher (Legendary, Nile, GOG, and manually added games)
 //! - Lutris
 //! - Bottles

--- a/src/linux/launchers/steam/steam_shortcuts.rs
+++ b/src/linux/launchers/steam/steam_shortcuts.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use itertools::Itertools;
 use nom::{
     bytes::complete::{take_till, take_until},
     character::complete::char,
@@ -57,7 +58,7 @@ impl ParsableDataCombined {
 
         ParsableDataCombined {
             title: shortcut_data.title,
-            app_id: screenshot_data.app_id.clone(),
+            app_id: screenshot_data.app_id,
             path_box_art,
         }
     }
@@ -87,6 +88,9 @@ fn find_userdata_files(
 
             let p = p.path();
             let path_config = p.join("config");
+            if !path_config.is_dir() {
+                return None;
+            }
 
             let path_screenshots = p.join("760").join("screenshots.vdf");
             if !path_screenshots.is_file() {
@@ -210,44 +214,47 @@ impl SteamShortcuts {
     }
 
     #[tracing::instrument(level = "trace")]
-    fn parse_combined_data(&self) -> Result<Option<Vec<ParsableDataCombined>>, GamesParsingError> {
-        let shortcut_files = find_userdata_files(&self.path_steam_userdata_dir)?;
+    fn parse_combined_data(&self) -> Result<Vec<ParsableDataCombined>, GamesParsingError> {
+        let userdata_files = find_userdata_files(&self.path_steam_userdata_dir)?;
 
-        // TODO: find way to know what user is logged in so we can choose the correct file
-        let Some(UserDataFiles {
-            path_shortcuts,
-            path_screenshots,
-            path_box_art_dir,
-        }) = shortcut_files.into_iter().next()
-        else {
-            // One of the paths could not be found, no shortcuts available for the user
-            return Ok(None);
-        };
+        userdata_files
+            .into_iter()
+            .map(
+                |UserDataFiles {
+                     path_shortcuts,
+                     path_screenshots,
+                     path_box_art_dir,
+                 }| {
+                    let shortcuts_data = get_parsable_shortcuts_data(&path_shortcuts)?;
+                    let mut screenshots_data = get_parsable_screenshots_data(&path_screenshots)?;
+                    dbg!(&shortcuts_data);
+                    dbg!(&screenshots_data);
 
-        let shortcuts_data = get_parsable_shortcuts_data(&path_shortcuts)?;
-        let mut screenshots_data = get_parsable_screenshots_data(&path_screenshots)?;
-
-        Ok(Some(
-            shortcuts_data
-                .iter()
-                .cloned()
-                .filter_map(|shortcut_data| {
-                    screenshots_data
-                        .iter_mut()
-                        // Reverse because the last entry is the newest one and this file doesn't seem to
-                        // get reset, so we want to take the one most likely to be correct
-                        .rev()
-                        .find(|d| !d.title.is_empty() && d.title == shortcut_data.title)
-                        .map(|screenshot_data| {
-                            ParsableDataCombined::combine(
-                                &path_box_art_dir,
-                                shortcut_data,
-                                mem::take(screenshot_data),
-                            )
+                    let res = shortcuts_data
+                        .into_iter()
+                        .filter_map(|shortcut_data| {
+                            screenshots_data
+                                .iter_mut()
+                                // Reverse because the last entry is the newest one and this file doesn't seem to
+                                // get reset, so we want to take the one most likely to be correct (in the
+                                // case of duplicate entries)
+                                .rev()
+                                .find(|d| !d.title.is_empty() && d.title == shortcut_data.title)
+                                .map(|screenshot_data| {
+                                    ParsableDataCombined::combine(
+                                        &path_box_art_dir,
+                                        shortcut_data,
+                                        mem::take(screenshot_data),
+                                    )
+                                })
                         })
-                })
-                .collect(),
-        ))
+                        .collect_vec();
+
+                    Ok::<Vec<ParsableDataCombined>, GamesParsingError>(res)
+                },
+            )
+            .flatten_ok()
+            .collect()
     }
 }
 
@@ -262,13 +269,10 @@ impl Launcher for SteamShortcuts {
 
     #[tracing::instrument(level = "trace")]
     fn get_detected_games(&self) -> GamesResult {
-        let shortcut_data = self
-            .parse_combined_data()
-            .map_err(|e| {
-                error!("{LAUNCHER} - {e}");
-                e
-            })?
-            .unwrap_or_default();
+        let shortcut_data = self.parse_combined_data().map_err(|e| {
+            error!("{LAUNCHER} - {e}");
+            e
+        })?;
 
         if shortcut_data.is_empty() {
             warn_no_games!();


### PR DESCRIPTION
In relation to #28 

Previously, only the first detected user data directory with the required files for defining shortcuts was being considered.

Ideally, only the ones for the currently logged in user would be parsed, but parsing shortcuts for all users will work better than the previous approach.

A note was also added to the README to let users know that the shortcuts need to be launched through Steam first for the required files to be generated/updated.